### PR TITLE
Attempt to cache dependencies in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 matrix:
   include:
     - name: "Python 3.6.5 on macOS (xcode9.4)"


### PR DESCRIPTION
However, it did not speed up the build at all. Can't hurt to use Pip caching though.